### PR TITLE
Add Transferring Start/End Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The `transfer` function returns a Promise for an object, called a "content objec
 * `blob` - a Blob containing the content of the retrieved resource
 * `options` - the request options
 
+TODO: document `jsua-transferring-started` and `jsua-transferring-ended` events
+
 ## building
 
 The `building` object has the following interface:
@@ -77,7 +79,7 @@ If the attacher determines that the view should be discarded:
 If the attacher determines that the view should be attached:
 * `attach` - a parameterless function that attaches the view to the view hierarchy; the return parameter is an array of the detached views, if any, or falsey.
 
-TODO: document `jsua-attach` and `jsua-detach` events after proving them out.
+TODO: document `jsua-attach` and `jsua-detach` events
 
 ## finishing
 

--- a/test/transferring/index.js
+++ b/test/transferring/index.js
@@ -54,4 +54,9 @@ describe("transferring", function () {
     
     transferring.transfer({ url: "foo://" }).should.eventually.equal(expected);
   });
+  
+  it("should raise 'jsua-transferring-started' event on the app view before starting a transfer");
+  it("should raise 'jsua-transferring-ended' event on the app view after a transfer has ended");
+  it("should assign 'pendingTransfers' to all events reporting total pending transfer count");
+  it("should assign 'originView' to the view that originated the transfer");
 });


### PR DESCRIPTION
This change adds `jsua-transferring-started` and
`jsua-transferring-ended` events to the transferring subsystem. The
events are dispatched on the app context view and include the count of
pending transfers and the view that originated the transfer.